### PR TITLE
Skipped status picked up by CTest

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ jobs:
       matrix:
         os: ['ubuntu-latest']
         pytest-major-version: ['2', '3', '4', '5', '6']
-      fail-fast: true
+      fail-fast: false
     name: ${{ matrix.os }} - Pytest ${{ matrix.pytest-major-version }}
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,3 +24,12 @@ jobs:
       - name: Test
         working-directory: build
         run: ctest
+
+      - name: Archive report
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: Report-Pytest${{ matrix.pytest-major-version }}
+          path: |
+            build/report/*.xml
+            build/Testing/Temporary/*.log

--- a/Pytest.cmake
+++ b/Pytest.cmake
@@ -29,7 +29,13 @@ This module defines functions to help integrate Pytest scripts into CMake.
   The options are:
 
   ``EXTRA_ARGS arg1...``
-    Any extra arguments to pass on the command line to each test case.
+    Any extra arguments to pass on the command line to pytest
+
+  ``COLLECTION_ARGS arg1...``
+    Extra arguments to pass to pytest during test case collection
+
+  ``EXECUTION_ARGS arg1...``
+    Extra arguments to pass to pytest during test case execution
 
   ``WORKING_DIRECTORY dir``
     Specifies the directory in which to run test case collection and test case
@@ -64,7 +70,7 @@ cmake_parse_arguments(
     ""
     ""
     "TEST_PREFIX;TEST_SUFFIX;WORKING_DIRECTORY;XML_OUTPUT_DIR"
-    "EXTRA_ARGS"
+    "EXTRA_ARGS;COLLECTION_ARGS;EXECUTION_ARGS"
     ${ARGN}
   )
 
@@ -74,8 +80,8 @@ cmake_parse_arguments(
   endif()
 
   # https://docs.pytest.org/en/6.2.x/example/pythoncollection.html#finding-out-what-is-collected
-  set(pytest_collection_args --collect-only -q ${_EXTRA_ARGS})
-  set(pytest_execution_args ${_EXTRA_ARGS})
+  set(pytest_collection_args --collect-only -q ${_EXTRA_ARGS} ${_COLLECTION_ARGS})
+  set(pytest_execution_args ${_EXTRA_ARGS} ${_EXECUTION_ARGS})
   set(pytest_base_command ${Python_EXECUTABLE} -m pytest)
 
   execute_process(
@@ -119,6 +125,8 @@ cmake_parse_arguments(
                 ${test_case} ${pytest_execution_args} ${pytest_local_args}
         WORKING_DIRECTORY ${_WORKING_DIRECTORY}
       )
+      # Pytest Exit code 5 means all tests were deselected
+      set_tests_properties("${test_case_name}" PROPERTIES SKIP_RETURN_CODE 5)
     endif()
 
   endforeach()

--- a/README.md
+++ b/README.md
@@ -37,6 +37,15 @@ pytest_discover_tests(
 
 For more information see the [module](Pytest.cmake) itself, it has inline documentation.
 
+### Skipped tests
+
+During execution tests that are deselected will be marked as skipped, this should only happen
+if the collection arguments were different than execution arguments. Skipped tests can also be
+picked up by ctest but this requires setting the exit code to 5 when no tests were executed,
+something which is not done by `pytest`, see issues [#812](https://github.com/pytest-dev/pytest/issues/812)
+and [#5689](https://github.com/pytest-dev/pytest/issues/5689).
+This can be solved with a few hooks, see [example conftest](example/conftest.py).
+
 ---
 
 ## License

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -9,6 +9,8 @@ include(../Pytest.cmake)
 
 pytest_discover_tests(
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    COLLECTION_ARGS "-m not slow"
+    EXECUTION_ARGS "-s"
     TEST_PREFIX "PYTEST_"
     TEST_SUFFIX "_${CMAKE_SYSTEM_PROCESSOR}"
     XML_OUTPUT_DIR ${CMAKE_CURRENT_BINARY_DIR}/report

--- a/example/conftest.py
+++ b/example/conftest.py
@@ -16,5 +16,13 @@ def pytest_runtest_makereport(item, call):
 
 @pytest.hookimpl(trylast=True)
 def pytest_sessionfinish(session: pytest.Session, exitstatus: int):
+    try:
+        # Before pytest 5 the values were contants
+        from _pytest.main import EXIT_NOTESTSCOLLECTED
+        no_tests_collected = EXIT_NOTESTSCOLLECTED
+    except ImportError:
+        # From pytest 5 on the values are inside an enum
+        from pytest import ExitCode
+        no_tests_collected = ExitCode.NO_TESTS_COLLECTED
     if test_executed and every_test_skipped:
-        session.exitstatus = pytest.ExitCode.NO_TESTS_COLLECTED
+        session.exitstatus = no_tests_collected

--- a/example/conftest.py
+++ b/example/conftest.py
@@ -1,0 +1,20 @@
+import pytest
+
+test_executed = False
+every_test_skipped = True
+
+@pytest.hookimpl(hookwrapper=True)
+def pytest_runtest_makereport(item, call):
+    global every_test_skipped, test_executed
+    outcome = yield
+    test_executed = True
+
+    rep = outcome.get_result()
+
+    if not rep.skipped and rep.when == 'setup':
+        every_test_skipped = False
+
+@pytest.hookimpl(trylast=True)
+def pytest_sessionfinish(session: pytest.Session, exitstatus: int):
+    if test_executed and every_test_skipped:
+        session.exitstatus = pytest.ExitCode.NO_TESTS_COLLECTED

--- a/example/integration/test_service.py
+++ b/example/integration/test_service.py
@@ -5,5 +5,6 @@ class TestService:
     def test_service_init(self):
         pass
 
+    @pytest.mark.slow
     def test_service_stop(self):
         pass


### PR DESCRIPTION
## Brief

- Skipped status can be picked up by CTest, when everything is deselected it will show up as skipped
  for skipped tests to show up as skipped we need to create pytest hooks to change the exit code
- Adds separate collection and execution arguments